### PR TITLE
Add example configuration files and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,69 @@
 A LoRA trainer notebook for training Illustrious LoRAs.
 
 ## Documentation
-
 - [Lambda Stack 22.04 arm64 environment setup](docs/setup.md)
+
+## Configuration overview
+
+Two TOML files under `project_name/configs/` provide reusable defaults for the notebook:
+
+- `training_config.example.toml` captures run metadata, optimizer options, and LoRA-specific knobs.
+- `dataset_config.example.toml` describes where image/caption pairs live and how validation previews are rendered.
+
+Copy the examples, rename them (for example `training_config.toml`), and point the "0. Load training configuration" and "0. Load dataset configuration" cells in **Illustriousxlnotebook.ipynb** at your customized files.
+
+### Training configuration parameters
+
+| Parameter | Description | Acceptable values | Notebook widget/cell |
+| --- | --- | --- | --- |
+| `experiment.run_name` | Human-readable label for the session and prefix for output folders. | Any ASCII string; keep under 64 characters to avoid filesystem limits. | "1. Run metadata" → **Run name** text box. |
+| `experiment.output_dir` | Directory where checkpoints, weights, and logs are stored. | Relative or absolute path; must be writable. | "1. Run metadata" → **Output directory** picker. |
+| `experiment.seed` | Random seed applied to Python, NumPy, and PyTorch. | Non-negative integer; commonly 0–9999. | "1. Run metadata" → **Seed** numeric field. |
+| `model.pretrained_model_name_or_path` | Base SDXL model to fine-tune. | Hugging Face repo ID or local path. | "2. Model preparation" → **Base model** dropdown/input. |
+| `optimizer.mixed_precision` | Precision mode for training. | `"bf16"`, `"fp16"`, or `"no"`. | "3. Optimizer setup" → **Mixed precision** selector. |
+| `optimizer.use_8bit_adam` | Toggle for bitsandbytes AdamW. | `true` or `false`. | "3. Optimizer setup" → **Use 8-bit Adam** switch. |
+| `training.train_batch_size` | Images processed per optimizer step before accumulation. | Integer 1–4 (GPU VRAM dependent). | "4. Training hyperparameters" → **Batch size** field. |
+| `training.gradient_accumulation_steps` | Gradient accumulation multiplier. | Integer 1–16; combined with batch size for effective batch. | "4. Training hyperparameters" → **Grad accumulation** field. |
+| `training.learning_rate` | Initial learning rate for AdamW. | Float 5e-5–1e-3 typical for LoRA. | "4. Training hyperparameters" → **Learning rate** slider. |
+| `training.lr_scheduler` | Learning rate scheduler strategy. | `"constant"`, `"cosine"`, or `"cosine_with_restarts"`. | "4. Training hyperparameters" → **Scheduler** dropdown. |
+| `training.lr_warmup_steps` | Steps before scheduler starts decaying LR. | Integer ≥0; 50–500 recommended. | "4. Training hyperparameters" → **Warmup steps** field. |
+| `training.max_train_epochs` | Number of dataset passes. | Integer ≥1; 5–15 common for 100 images. | "4. Training hyperparameters" → **Epochs** field. |
+| `training.checkpointing_steps` | Interval for saving checkpoints. | Integer ≥50; align with dataset size. | "5. Checkpointing" → **Save every N steps** field. |
+| `training.dataloader_num_workers` | Parallel workers for data loading. | Integer 0–8 depending on CPU threads. | "4. Training hyperparameters" → **DataLoader workers** field. |
+| `lora.network_rank` | Rank of LoRA decomposition. | Integer 4–64; higher consumes more VRAM. | "6. LoRA configuration" → **Network rank** slider. |
+| `lora.network_alpha` | Scaling factor applied to LoRA layers. | Integer or float, typically 0.5–2× rank. | "6. LoRA configuration" → **Network alpha** field. |
+
+### Dataset configuration parameters
+
+| Parameter | Description | Acceptable values | Notebook widget/cell |
+| --- | --- | --- | --- |
+| `dataset.root` | Base directory for the dataset. | Existing directory path. | "2. Dataset setup" → **Dataset root** picker. |
+| `dataset.train_folder` | Subfolder holding training pairs. | Relative path inside `root`. | "2. Dataset setup" → **Training folder** text field. |
+| `dataset.caption_extension` | Required caption suffix matching images. | `.txt`, `.json`, etc.; defaults to `.txt`. | "2. Dataset setup" → **Caption extension** selector. |
+| `dataset.image_extensions` | Allowed image formats. | List of lowercase extensions (e.g., `.jpg`). | "2. Dataset setup" → **Image extensions** multi-select. |
+| `dataset.max_train_images` | Limit on processed pairs. | Integer ≥1; set to dataset size to include all. | "2. Dataset setup" → **Max images** numeric input. |
+| `dataset.resolution` | Target square resolution for crops/resizes. | Integer multiple of 64; SDXL defaults to 1024. | "2. Dataset setup" → **Resolution** field. |
+| `dataset.shuffle_before_validation` | Shuffle pairs before reserving validation prompts. | `true` or `false`. | "2. Dataset setup" → **Shuffle before validation** toggle. |
+| `validation.prompt` | Positive prompt for preview renders. | Any prompt string using trigger token. | "7. Validation preview" → **Prompt** textarea. |
+| `validation.negative_prompt` | Negative prompt for previews. | Any prompt string; can be empty. | "7. Validation preview" → **Negative prompt** textarea. |
+| `validation.num_images` | Number of images to generate during preview. | Integer 1–8 recommended. | "7. Validation preview" → **Images to render** field. |
+| `concept.trigger_token` | Token inserted in prompts to call the concept. | Custom string such as `<sks-person>`. | "6. LoRA configuration" → **Trigger token** field. |
+| `concept.prior_loss_weight` | Weight for prior preservation loss. | Float 0.0–1.0. | "6. LoRA configuration" → **Prior loss weight** slider. |
+
+## Dataset layout and validation
+
+Place your training assets inside `dataset/train/` as matched `.jpg` (or `.png`) images with corresponding caption files using the same stem and the extension defined in your dataset configuration. For example:
+
+```
+dataset/
+  train/
+    subject_0001.jpg
+    subject_0001.txt
+    subject_0002.jpg
+    subject_0002.txt
+    ...
+```
+
+The notebook's "2. Dataset setup" cell scans `dataset.train_folder`, confirms that every image listed has a caption with the same filename stem, and warns you in-line if any pairs are missing. Only validated pairs contribute toward the `dataset.max_train_images` count before training begins. Validation preview prompts can optionally live under `dataset/validation/` if you want to manage them alongside your training data; update the TOML paths accordingly.
+
+Keep filenames alphanumeric with underscores to avoid shell parsing issues, and ensure captions are UTF-8 encoded plain text.

--- a/project_name/configs/dataset_config.example.toml
+++ b/project_name/configs/dataset_config.example.toml
@@ -1,0 +1,32 @@
+# Example dataset configuration for the Illustrious XL LoRA notebook.
+# The "0. Load dataset configuration" cell consumes these keys before building the dataset.
+
+[dataset]
+# Base path located by the file picker in "2. Dataset setup".
+root = "dataset"
+# Subdirectory under root containing the 100 training .jpg/.txt pairs.
+train_folder = "train"
+# Caption extension enforced in "2. Dataset setup"; one caption file per image.
+caption_extension = ".txt"
+# Image suffixes accepted by the notebook's loader (ensure lower-case for matching).
+image_extensions = [".jpg", ".png"]
+# Cap on how many pairs to ingest; the notebook stops counting after this many valid items.
+max_train_images = 100
+# Square resize applied during preprocessing in "2. Dataset setup"; SDXL LoRAs target 1024.
+resolution = 1024
+# Shuffle toggle in "2. Dataset setup" before reserving validation previews.
+shuffle_before_validation = true
+
+[validation]
+# Prompt used in "7. Validation preview" to render example outputs.
+prompt = "A portrait of <sks-person> in cinematic lighting"
+# Negative prompt text area in "7. Validation preview".
+negative_prompt = "blurry, low quality"
+# Number of preview images the notebook will request when validation runs.
+num_images = 4
+
+[concept]
+# Trigger word typed into "6. LoRA configuration" to bind the learned concept.
+trigger_token = "<sks-person>"
+# Weight slider in "6. LoRA configuration" balancing prior preservation (0.0-1.0 typical).
+prior_loss_weight = 0.1

--- a/project_name/configs/training_config.example.toml
+++ b/project_name/configs/training_config.example.toml
@@ -1,0 +1,44 @@
+# Example training configuration for the Illustrious XL LoRA notebook.
+# Every field is consumed by the "0. Load training configuration" cell inside Illustriousxlnotebook.ipynb.
+
+[experiment]
+# Displayed in "1. Run metadata" widget and prefixes output folders/log files.
+run_name = "xl_lora_example"
+# Directory created in "1. Run metadata" to store checkpoints, LoRA weights, and logs.
+output_dir = "outputs/xl_lora_example"
+# Seed applied in "1. Run metadata" to make training reproducible across restarts.
+seed = 42
+
+[model]
+# Base model pulled in "2. Model preparation"; set to any SDXL-compatible identifier or local path.
+pretrained_model_name_or_path = "stabilityai/stable-diffusion-xl-base-1.0"
+
+[optimizer]
+# Precision mode toggled in "3. Optimizer setup" (valid: "bf16", "fp16", "no").
+mixed_precision = "bf16"
+# Enables bitsandbytes AdamW in "3. Optimizer setup" to reduce VRAM use when true.
+use_8bit_adam = true
+
+[training]
+# Mini-batch size selected in "4. Training hyperparameters" (1-4 recommended for 24GB cards).
+train_batch_size = 2
+# Number of accumulation steps set in the same cell; effective batch = batch_size * gradient_accumulation_steps.
+gradient_accumulation_steps = 4
+# Learning rate slider in "4. Training hyperparameters"; tune between 5e-5 and 1e-3 for LoRA.
+learning_rate = 0.0001
+# Scheduler dropdown in "4. Training hyperparameters" (options: "constant", "cosine", "cosine_with_restarts").
+lr_scheduler = "cosine_with_restarts"
+# Warmup steps before LR schedule kicks in; matches numeric field in "4. Training hyperparameters".
+lr_warmup_steps = 100
+# Number of epochs the dataset is iterated over; align with the integer box in "4. Training hyperparameters".
+max_train_epochs = 10
+# Interval for saving intermediate checkpoints, configured in "5. Checkpointing".
+checkpointing_steps = 500
+# DataLoader workers value from "4. Training hyperparameters"; 0-8 typical on Linux workstations.
+dataloader_num_workers = 4
+
+[lora]
+# Rank slider in "6. LoRA configuration" (valid range 4-64; 8 works well for portraits).
+network_rank = 8
+# Scaling factor box in "6. LoRA configuration"; usually 1-2x the rank for SDXL.
+network_alpha = 16


### PR DESCRIPTION
## Summary
- add example training and dataset configuration TOML files with notebook cell references
- document configuration parameters, acceptable ranges, and dataset layout expectations in the README

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d817cb048c8320a8be94ca0b69a582